### PR TITLE
Remove unnecessary `extensible-exceptions` dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, base, bytestring, extensible-exceptions
+{ mkDerivation, base, bytestring
 , happstack-server, hslogger, HsOpenSSL, network, openssl, sendfile
 , stdenv, time, unix
 }:
@@ -7,7 +7,7 @@ mkDerivation {
   version = "7.1.6";
   src = ./.;
   libraryHaskellDepends = [
-    base bytestring extensible-exceptions happstack-server hslogger
+    base bytestring happstack-server hslogger
     HsOpenSSL network sendfile time unix
   ];
   librarySystemDepends = [ openssl ];

--- a/happstack-server-tls.cabal
+++ b/happstack-server-tls.cabal
@@ -42,9 +42,8 @@ Library
                        Happstack.Server.Internal.TLS
                        Happstack.Server.SimpleHTTPS
 
-    Build-Depends:     base                  <  5,
+    Build-Depends:     base                  >= 4 && < 5,
                        bytestring            >= 0.9 && < 0.13,
-                       extensible-exceptions == 0.1.*,
                        happstack-server      >= 6.6.4 && < 7.10,
                        hslogger              >= 1.1 && < 1.4,
                        HsOpenSSL             >= 0.10 && < 0.12,

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ let
 
   inherit (nixpkgs) pkgs;
 
-  f = { mkDerivation, base, bytestring, extensible-exceptions
+  f = { mkDerivation, base, bytestring
       , happstack-server, hslogger, HsOpenSSL, network, openssl, sendfile
       , stdenv, time, unix, cabal-install
       }:
@@ -13,7 +13,7 @@ let
         version = "7.1.6";
         src = ./.;
         libraryHaskellDepends = [
-          base bytestring extensible-exceptions happstack-server hslogger
+          base bytestring happstack-server hslogger
           HsOpenSSL network sendfile time unix
         ];
         librarySystemDepends = [ openssl ];

--- a/src/Happstack/Server/Internal/TLS.hs
+++ b/src/Happstack/Server/Internal/TLS.hs
@@ -4,7 +4,7 @@
 module Happstack.Server.Internal.TLS where
 
 import Control.Concurrent                         (forkIO, killThread, myThreadId)
-import Control.Exception.Extensible               as E
+import Control.Exception                          as E
 import Control.Monad                              (forever, when)
 import Data.Time                                  (UTCTime)
 import GHC.IO.Exception                           (IOErrorType(..))


### PR DESCRIPTION
For `base >= 4`, `extensible-exceptions` simply reexports `Control.Exception`.